### PR TITLE
Improve mobile performance and SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>One‑Weekend Websites — Launch‑Ready in 48 Hours | Jordan Lander</title>
   <meta name="description" content="Productized website build: Launch‑ready, mobile‑first one‑page sites for local businesses in 48 hours. Flat $499. Optional domain setup + photo pass. Book a free 15‑minute fit check." />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#0b0d10" />
 
   <!-- Open Graph / Twitter -->
   <meta property="og:title" content="One‑Weekend Websites — Launch‑Ready in 48 Hours" />
@@ -12,9 +14,11 @@
   <meta property="og:type" content="website" />
   <meta property="og:image" content="/og-card.jpg" />
   <meta property="og:url" content="https://www.oneweekendwebsites.com/" />
+  <meta property="og:site_name" content="One‑Weekend Websites" />
   <meta name="twitter:card" content="summary_large_image" />
 
   <link rel="canonical" href="https://www.oneweekendwebsites.com/" />
+  <link rel="apple-touch-icon" href="/logo.jpg" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>⚡</text></svg>">
 
   <style>
@@ -95,7 +99,7 @@
   <div class="container">
     <header>
       <a class="brand" href="#">
-        <img class="logo" src="/logo.jpg" alt="One‑Weekend Websites logo" />
+        <img class="logo" src="/logo.jpg" alt="One‑Weekend Websites logo" decoding="async" />
         <div>
           <div style="font-weight:900;letter-spacing:.3px">One‑Weekend Websites</div>
           <div style="color:var(--muted);font-size:12px">Launch‑ready in 48 hours</div>
@@ -213,7 +217,7 @@
       <div class="grid cols-3">
         <div class="card" style="padding:10px">
           <a href="https://www.integrityevsolutions.com" target="_blank" rel="noopener">
-            <img alt="Integrity EV Solutions — EV charger installs in Northern Georgia / Atlanta" style="width:100%;border-radius:12px;border:1px solid #1e2633" src="/work-integrity-ev.jpg"/>
+            <img alt="Integrity EV Solutions — EV charger installs in Northern Georgia / Atlanta" style="width:100%;border-radius:12px;border:1px solid #1e2633" src="/work-integrity-ev.jpg" loading="lazy" decoding="async"/>
           </a>
           <div style="margin-top:8px">
             <strong>Integrity EV Solutions</strong>
@@ -226,7 +230,7 @@
         </div>
         <div class="card" style="padding:10px">
           <a href="https://girardarts.org" target="_blank" rel="noopener">
-            <img alt="Girard Music & Drama Boosters — community support for music & theatre education" style="width:100%;border-radius:12px;border:1px solid #1e2633" src="/work-girard-arts.jpg"/>
+            <img alt="Girard Music & Drama Boosters — community support for music & theatre education" style="width:100%;border-radius:12px;border:1px solid #1e2633" src="/work-girard-arts.jpg" loading="lazy" decoding="async"/>
           </a>
           <div style="margin-top:8px">
             <strong>Girard Music & Drama Boosters</strong>
@@ -239,7 +243,7 @@
         </div>
         <div class="card" style="padding:10px">
           <a href="https://www.wileytrucking.com" target="_blank" rel="noopener">
-            <img alt="Wiley Trucking Fleet — Coast‑to‑coast freight from Erie, PA" style="width:100%;border-radius:12px;border:1px solid #1e2633" src="/work-wiley-trucking.jpg"/>
+            <img alt="Wiley Trucking Fleet — Coast‑to‑coast freight from Erie, PA" style="width:100%;border-radius:12px;border:1px solid #1e2633" src="/work-wiley-trucking.jpg" loading="lazy" decoding="async"/>
           </a>
           <div style="margin-top:8px">
             <strong>Wiley Trucking Fleet</strong>


### PR DESCRIPTION
## Summary
- add robots and theme-color meta tags for clearer SEO and mobile theming
- declare site_name and apple-touch-icon for richer previews on mobile
- enable async decoding and lazy loading on images to boost mobile performance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b569bd9d5083319c0bf3a02c9bedb5