### PR TITLE
Add responsive hamburger navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,16 +51,17 @@
           <div style="color:var(--muted);font-size:12px">Launch‑ready in 48 hours</div>
         </div>
       </a>
-      <nav>
-        <a href="#pricing">Pricing</a>
-        <a href="#process">Process</a>
-        <a href="#work">Work</a>
-        <a href="#faq">FAQ</a>
-        <a href="#book">Book</a>
-        <a href="#contact">Contact</a>
-        <a href="https://jordanlander.com" target="_blank" rel="noopener">About</a>
-      </nav>
-    </header>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Toggle navigation" type="button">☰</button>
+        <nav id="primary-nav" aria-label="Primary">
+          <a href="#pricing">Pricing</a>
+          <a href="#process">Process</a>
+          <a href="#work">Work</a>
+          <a href="#faq">FAQ</a>
+          <a href="#book">Book</a>
+          <a href="#contact">Contact</a>
+          <a href="https://jordanlander.com" target="_blank" rel="noopener">About</a>
+        </nav>
+      </header>
 
     <section class="hero">
       <div>
@@ -317,9 +318,33 @@
           <a href="#faq">Refunds</a>
         </div>
       </div>
-    </footer>
+  </footer>
   </div>
-
+  <script>
+    (function(){
+      var toggle = document.querySelector('.nav-toggle');
+      var menu = document.getElementById('primary-nav');
+      if(!toggle || !menu) return;
+      var firstLink = menu.querySelector('a');
+      toggle.addEventListener('click', function(){
+        var expanded = this.getAttribute('aria-expanded') === 'true';
+        this.setAttribute('aria-expanded', String(!expanded));
+        menu.classList.toggle('open', !expanded);
+        if (!expanded && firstLink) {
+          firstLink.focus();
+        } else {
+          this.focus();
+        }
+      });
+      document.addEventListener('keydown', function(e){
+        if (e.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true') {
+          toggle.setAttribute('aria-expanded', 'false');
+          menu.classList.remove('open');
+          toggle.focus();
+        }
+      });
+    })();
+  </script>
   <script>
     document.getElementById('y').textContent = new Date().getFullYear();
   </script>

--- a/styles.css
+++ b/styles.css
@@ -7,11 +7,18 @@
     html,body{margin:0;background:var(--bg);color:var(--text);font:16px/1.6 system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial, sans-serif}
     a{color:var(--accent)}
     .container{max-width:1100px;margin:0 auto;padding:24px}
-    header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:16px 0}
+    header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:16px 0;position:relative}
     .brand{display:flex;align-items:center;gap:12px;text-decoration:none;color:var(--text)}
     .logo{width:34px;height:34px;border-radius:10px;display:block;object-fit:cover;box-shadow:var(--shadow)}
+    .nav-toggle{display:none;background:none;border:0;color:var(--text);font-size:26px;cursor:pointer}
+    nav{display:flex}
     nav a{margin:0 10px;color:var(--muted);text-decoration:none;font-weight:600}
     nav a:hover{color:var(--text)}
+    @media (max-width:700px){
+      nav{display:none;flex-direction:column;gap:8px;position:absolute;top:100%;right:0;background:var(--card);padding:10px 14px;border:1px solid #1e2633;border-radius:var(--radius)}
+      nav.open{display:flex}
+      .nav-toggle{display:block}
+    }
 
     .hero{display:grid;grid-template-columns:1.1fr .9fr;gap:28px;align-items:center;padding:36px 0}
     .title{font-size:clamp(28px,5vw,46px);line-height:1.1;margin:0 0 12px 0}


### PR DESCRIPTION
## Summary
- replace static nav with hamburger button and hidden menu structure
- add media query styles and script to toggle menu visibility with aria-expanded
- manage focus and Escape key for keyboard-friendly navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b56dd514e08331a115d8fa7907f2d7