### PR TITLE
feat: add hero gradient and button transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,8 +63,8 @@
       </nav>
     </div>
   </header>
-  <div class="container">
-    <section class="hero">
+  <section class="hero">
+    <div class="container hero-content">
       <div>
         <span class="badge">$499 flat • Mobile‑first • Small‑biz friendly</span>
         <h1 class="title">Your website, live by <em>Monday.</em></h1>
@@ -106,8 +106,10 @@
           <span class="pill">2 openings this month</span>
         </div>
       </div>
-    </section>
+    </div>
+  </section>
 
+  <div class="container">
     <section id="pricing" class="grid cols-3">
       <div class="card pricing">
         <p class="kicker">Core Package</p>

--- a/styles.css
+++ b/styles.css
@@ -21,21 +21,25 @@
       .nav-toggle{display:block}
     }
 
-    .hero{display:grid;grid-template-columns:1.1fr .9fr;gap:28px;align-items:center;padding:36px 0}
+    .hero{background:linear-gradient(135deg,#0f1319,#1e293b)}
+    .hero-content{display:grid;grid-template-columns:1.1fr .9fr;gap:28px;align-items:center;padding:36px 24px}
     .title{font-size:clamp(28px,5vw,46px);line-height:1.1;margin:0 0 12px 0}
     .subtitle{color:var(--muted);font-size:clamp(16px,2.6vw,18px);margin:0 0 18px}
-    .badge{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;background:#0f1720;border:1px solid #1f2937;color:#cce7ff;font-weight:700;font-size:13px;margin-bottom:12px}
+    .badge{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;background:#0f1720;border:1px solid #1f2937;color:#cce7ff;font-weight:700;font-size:13px;margin-bottom:12px;transition:background .3s,transform .3s}
+    .badge:hover{background:#17212e;transform:translateY(-2px)}
     .cta-row{display:flex;flex-wrap:wrap;gap:12px;margin:18px 0}
-    .btn{appearance:none;border:0;cursor:pointer;padding:12px 16px;border-radius:12px;font-weight:800;letter-spacing:.2px}
+    .btn{appearance:none;border:0;cursor:pointer;padding:12px 16px;border-radius:12px;font-weight:800;letter-spacing:.2px;transition:background .3s,color .3s,transform .3s,opacity .3s}
+    .btn:hover{transform:translateY(-2px);opacity:.9}
     .btn-primary{background:linear-gradient(135deg,var(--accent-2),var(--accent));color:#081018;box-shadow:var(--shadow)}
     .btn-outline{background:transparent;color:var(--text);border:1.5px solid #2c3442}
+    .btn-outline:hover{background:rgba(125,211,252,.15)}
     .trust{display:flex;flex-wrap:wrap;gap:18px;color:var(--muted);font-size:14px}
     .card{background:var(--card);border:1px solid #1e2633;border-radius:var(--radius);box-shadow:var(--shadow)}
 
     .grid{display:grid;gap:18px}
     .grid.cols-3{grid-template-columns:repeat(3,1fr)}
     .grid.cols-2{grid-template-columns:repeat(2,1fr)}
-    @media (max-width:900px){.hero{grid-template-columns:1fr}.grid.cols-3{grid-template-columns:1fr}.grid.cols-2{grid-template-columns:1fr}}
+    @media (max-width:900px){.hero-content{grid-template-columns:1fr}.grid.cols-3{grid-template-columns:1fr}.grid.cols-2{grid-template-columns:1fr}}
 
     .pricing{padding:8px 18px 18px}
     .pricing h3{margin:10px 0 0}


### PR DESCRIPTION
## Summary
- introduce dedicated hero section with gradient background
- add hover transitions for badge and buttons
- keep layout responsive with updated media queries

## Testing
- `python - <<'PY'
from math import pow

def hex_to_rgb(hex_str):
    hex_str = hex_str.lstrip('#')
    return tuple(int(hex_str[i:i+2], 16)/255 for i in (0,2,4))

def rel_lum(rgb):
    def channel(c):
        if c <= 0.03928:
            return c/12.92
        else:
            return ((c+0.055)/1.055)**2.4
    r,g,b = rgb
    return 0.2126*channel(r) + 0.7152*channel(g) + 0.0722*channel(b)

def contrast_ratio(hex1, hex2):
    L1 = rel_lum(hex_to_rgb(hex1))
    L2 = rel_lum(hex_to_rgb(hex2))
    lighter = max(L1, L2)
    darker = min(L1, L2)
    return (lighter + 0.05) / (darker + 0.05)

text = '#eaf2ff'
backgrounds = ['#0f1319', '#1e293b']
for bg in backgrounds:
    print(bg, 'contrast ratio:', contrast_ratio(text, bg))
PY`
- `npx --yes playwright screenshot file://$(pwd)/index.html desktop.png --viewport-size=1280,800` *(fails: missing Chromium dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68b5b34192c0833192544893b5eea2cb