### PR TITLE
Add ProfessionalService schema for local SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,33 @@
   }
   </script>
 
+  <!-- JSON-LD schema for local business -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"ProfessionalService",
+    "name":"One-Weekend Websites",
+    "image":"https://www.oneweekendwebsites.com/logo.jpg",
+    "url":"https://www.oneweekendwebsites.com/",
+    "telephone":"+1-814-580-8040",
+    "priceRange":"$$",
+    "address":{
+      "@type":"PostalAddress",
+      "addressLocality":"Lake City",
+      "addressRegion":"PA",
+      "addressCountry":"US"
+    },
+    "areaServed":[
+      {"@type":"City","name":"Erie"},
+      {"@type":"City","name":"Girard"},
+      {"@type":"City","name":"Fairview"}
+    ],
+    "sameAs":[
+      "https://cal.com/jordanlander/fit-check-15"
+    ]
+  }
+  </script>
+
   <!-- JSON-LD schema for FAQ -->
   <script type="application/ld+json">
   {


### PR DESCRIPTION
## Summary
- add ProfessionalService JSON-LD with phone, service area, and sameAs link

## Testing
- `npm test` (fails: ENOENT no package.json)
- `curl -s -o /tmp/richresults.html -w "%{http_code}\n" "https://search.google.com/test/rich-results?view=JSON-LD&code=${ENCODED}"` (400 Bad Request)


------
https://chatgpt.com/codex/tasks/task_e_68b61f9887348331a86dd344a70ffcfc