### PR TITLE
Ensure privacy link visible and fix mobile footer overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,7 +381,7 @@
         <div style="text-align:right">
           <a href="#faq" style="margin-right:12px">Terms</a>
           <a href="#faq" style="margin-right:12px">Refunds</a>
-          <a href="privacy.html">Privacy</a>
+          <a href="/privacy.html">Privacy</a>
         </div>
       </div>
   </footer>

--- a/privacy.html
+++ b/privacy.html
@@ -48,7 +48,7 @@
       <div style="text-align:right">
         <a href="/#faq" style="margin-right:12px">Terms</a>
         <a href="/#faq" style="margin-right:12px">Refunds</a>
-        <a href="privacy.html">Privacy</a>
+          <a href="/privacy.html">Privacy</a>
       </div>
     </div>
   </footer>

--- a/styles.css
+++ b/styles.css
@@ -85,5 +85,5 @@
         #sticky-cta{display:none}
         #mobile-sticky{position:fixed;left:0;right:0;bottom:0;display:flex;gap:8px;padding:10px;background:#0b0d10cc;backdrop-filter:blur(8px);z-index:50}
         #mobile-sticky a{flex:1}
-        footer{margin-bottom:80px}
+        body{padding-bottom:90px}
       }


### PR DESCRIPTION
## Summary
- Link to privacy policy from footer using absolute path
- Add body bottom padding on mobile to keep footer visible beneath sticky CTA bar

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6316050408331adc2427da7fea460