### PR TITLE
Add logo preview metadata and highlight affordability

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,18 +4,20 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>One‑Weekend Websites — Launch‑Ready in 48 Hours | Jordan Lander</title>
-  <meta name="description" content="Productized website build: Launch‑ready, mobile‑first one‑page sites for local businesses in 48 hours. Flat $499. Optional domain setup + photo pass. Book a free 15‑minute fit check." />
+  <meta name="description" content="Productized website build: Launch‑ready, mobile‑first, affordable one‑page sites for local businesses in 48 hours. Flat $499. Optional domain setup + photo pass. Book a free 15‑minute fit check." />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0b0d10" />
 
   <!-- Open Graph / Twitter -->
   <meta property="og:title" content="One‑Weekend Websites — Launch‑Ready in 48 Hours" />
-  <meta property="og:description" content="Clean, fast one‑page sites for barbers, thrift/vintage, lawn care, churches, boosters, Etsy sellers. $499 flat. 48‑hour turnaround." />
+  <meta property="og:description" content="Clean, fast, affordable one‑page sites for barbers, thrift/vintage, lawn care, churches, boosters, Etsy sellers. $499 flat. 48‑hour turnaround." />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="/og-card.jpg" />
+  <meta property="og:image" content="https://www.oneweekendwebsites.com/logo.jpg" />
+  <meta property="og:image:alt" content="One‑Weekend Websites logo" />
   <meta property="og:url" content="https://www.oneweekendwebsites.com/" />
   <meta property="og:site_name" content="One‑Weekend Websites" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://www.oneweekendwebsites.com/logo.jpg" />
 
   <link rel="canonical" href="https://www.oneweekendwebsites.com/" />
   <link rel="apple-touch-icon" href="/logo.jpg" />
@@ -121,7 +123,7 @@
       <div>
         <span class="badge">$499 flat • Mobile‑first • Small‑biz friendly</span>
         <h1 class="title">Your website, live by <em>Monday.</em></h1>
-        <p class="subtitle">A clean, fast one‑page site for barbers, thrift/vintage, lawn care, churches, boosters, Etsy sellers—built over a single weekend. You provide the basics; I handle the rest.</p>
+        <p class="subtitle">A clean, fast, affordable one‑page site for barbers, thrift/vintage, lawn care, churches, boosters, Etsy sellers—built over a single weekend. You provide the basics; I handle the rest.</p>
         <div class="cta-row">
           <a class="btn btn-primary" href="#book">Book a free 15‑min fit check</a>
           <a class="btn btn-outline" href="#pricing">See what’s included</a>


### PR DESCRIPTION
## Summary
- Update Open Graph and Twitter metadata to use logo.jpg for link previews
- Mention affordability in meta description and hero subtitle

## Testing
- `npx htmlhint index.html privacy.html`


------
https://chatgpt.com/codex/tasks/task_e_68b8df34aff08331ac73baf117015b35