### PR TITLE
Add Google Analytics snippet

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -6,6 +6,15 @@
   <meta name="robots" content="noindex">
   <link rel="canonical" href="https://cal.com/jordanlander/fit-check-15?utm_source=domain&utm_medium=redirect&utm_campaign=book_short">
   <meta http-equiv="refresh" content="0; url=https://cal.com/jordanlander/fit-check-15?utm_source=domain&utm_medium=redirect&utm_campaign=book_short">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SX1PBTTNDW"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-SX1PBTTNDW');
+  </script>
   <script>
     window.location.replace("https://cal.com/jordanlander/fit-check-15?utm_source=domain&utm_medium=redirect&utm_campaign=book_short");
   </script>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,16 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SX1PBTTNDW"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-SX1PBTTNDW');
+  </script>
+
   <!-- JSON-LD schema for a productized service -->
   <script type="application/ld+json">
   {

--- a/privacy.html
+++ b/privacy.html
@@ -14,6 +14,16 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SX1PBTTNDW"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-SX1PBTTNDW');
+  </script>
 </head>
 <body>
   <header class="site-header">


### PR DESCRIPTION
## Summary
- integrate Google Analytics gtag.js snippet across public pages for site metrics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e44ed9d48331acdf449fad54332a