### PR TITLE
Fix mobile footer overlap and sticky nav behavior

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -35,7 +35,7 @@
   </script>
 </head>
 <body>
-  <header class="site-header">
+  <header class="site-header sticky">
     <div class="container">
       <a class="brand" href="/">
         <img class="logo" src="/logo.jpg" alt="One‑Weekend Websites logo" decoding="async" />

--- a/styles.css
+++ b/styles.css
@@ -41,8 +41,10 @@ h2{font-size:28px;margin:6px 0 12px}
 header.sticky{position:sticky;top:0;background:#ffffffcc;backdrop-filter:blur(10px);border-bottom:1px solid #EEF2F7;z-index:50}
 #mobile-sticky{display:none}
 @media (max-width:900px){
-  #mobile-sticky{position:fixed;left:0;right:0;bottom:0;background:#0b0d10cc;backdrop-filter:blur(10px);padding:10px;gap:8px;z-index:60;display:flex}
+  body{padding-bottom:calc(80px + env(safe-area-inset-bottom))}
+  #mobile-sticky{position:fixed;left:0;right:0;bottom:0;background:#0b0d10cc;backdrop-filter:blur(10px);padding:10px;padding-bottom:calc(10px + env(safe-area-inset-bottom));gap:8px;z-index:60;display:flex}
   #mobile-sticky a{flex:1}
+  footer{margin-bottom:calc(80px + env(safe-area-inset-bottom))}
 }
 img[loading="lazy"]{content-visibility:auto}
 


### PR DESCRIPTION
## Summary
- prevent mobile sticky buttons from covering footer by adding padding and safe-area support
- make privacy page header sticky for consistent navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba714193248331aa48aa04ec92bc5b