### PR TITLE
Add optional site steward plan and FAQ entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
     "mainEntity":[
       {"@type":"Question","name":"What do you need from me to start?","acceptedAnswer":{"@type":"Answer","text":"Logo (or name), brand color (hex if you have it), hours, address, services, and 3–6 photos. That’s it. A quick 15‑minute fit check locks it in."}},
       {"@type":"Question","name":"How do payments work?","acceptedAnswer":{"@type":"Answer","text":"Small deposit to reserve a weekend slot; balance on launch. Card payments via Stripe/Square. Receipts provided."}},
+      {"@type":"Question","name":"Is there a monthly fee?","acceptedAnswer":{"@type":"Answer","text":"No. $499 is flat for your 48-hour build and launch. After launch, you can DIY everything (I give you the handoff doc), or choose an optional Site Steward plan if you want me to keep an eye on renewals, DNS/SSL, and tiny tweaks."}},
       {"@type":"Question","name":"Can I add more pages later?","acceptedAnswer":{"@type":"Answer","text":"Yes—this is a foundation. We can add pages/sections later as separate mini‑projects."}},
       {"@type":"Question","name":"Do you handle domains and email?","acceptedAnswer":{"@type":"Answer","text":"Yes, via the Custom Domain Setup add‑on (DNS, SSL, www/non‑www, and basic email forwarding)."}},
       {"@type":"Question","name":"Accessibility?","acceptedAnswer":{"@type":"Answer","text":"We follow sensible defaults: semantic HTML, alt text, color‑contrast checks, and keyboard‑navigable controls."}},
@@ -211,6 +212,22 @@
         </ul>
         <p class="small">Keeps the weekend sprint realistic—and the price flat.</p>
       </div>
+
+      <div class="card pricing steward">
+        <p class="kicker">Optional Care</p>
+        <h3>Site Steward</h3>
+        <p class="price">$149/yr</p>
+        <p class="small">(or $19/mo · no contract)</p>
+        <ul class="list">
+          <li>We keep DNS & SSL current</li>
+          <li>Renewal reminders (I’ll press the button)</li>
+          <li>Quarterly checkup (links/phone/booking)</li>
+          <li>1 tiny update/quarter</li>
+        </ul>
+        <p class="small">$499 covers your build & launch. This plan is just for people who want hands-off peace of mind.</p>
+        <p class="small">If you’ll include the domain when you hold it:</p>
+        <p class="small"><strong>Site Steward+</strong> — $199/yr (includes 1 domain renewal)</p>
+      </div>
     </section>
 
     <section id="process" class="card steps" style="margin-top:22px" aria-label="Process">
@@ -278,6 +295,10 @@
         <details>
           <summary>How do payments work?</summary>
           <p>Small deposit to reserve a weekend slot; balance on launch. Card payments via Stripe/Square. Receipts provided.</p>
+        </details>
+        <details>
+          <summary>Is there a monthly fee?</summary>
+          <p>No. $499 is flat for your 48-hour build and launch. After launch, you can DIY everything (I give you the handoff doc), or choose an optional Site Steward plan if you want me to keep an eye on renewals, DNS/SSL, and tiny tweaks.</p>
         </details>
         <details>
           <summary>Can I add more pages later?</summary>

--- a/styles.css
+++ b/styles.css
@@ -50,6 +50,7 @@
 
     .pricing{padding:8px 18px 18px}
     .pricing h3{margin:10px 0 0}
+    .pricing.steward{grid-column:1 / -1;max-width:320px;justify-self:center}
     .price{font-size:30px;font-weight:900;margin:0}
     .inc{color:#cce7ff;margin:8px 0 0}
     .small{font-size:13px;color:var(--muted)}


### PR DESCRIPTION
## Summary
- Add Optional Care "Site Steward" card to pricing and align styling with modern pricing cards
- Document monthly fee policy and schema FAQ update

## Testing
- `npx htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b6689eb0288331af39ac5b263be75a