### PR TITLE
Add Site Steward plan and FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,18 @@
       <p>Optimize up to 10 photos for speed and clarity.</p>
       <ul class="list"><li>✔ Compress &amp; crop</li><li>✔ Color/contrast tune</li></ul>
     </div>
+    <div class="card" style="padding:16px">
+      <div class="kicker">Optional Care (no contract)</div>
+      <p style="font-weight:600;margin:6px 0">Site Steward — $149/yr <span class="small">(or $19/mo)</span></p>
+      <ul class="list">
+        <li>✔ We keep DNS &amp; SSL current</li>
+        <li>✔ Renewal reminders (I’ll press the button)</li>
+        <li>✔ Quarterly checkup (links/phone/booking)</li>
+        <li>✔ 1 tiny update/quarter</li>
+      </ul>
+      <p class="small">$499 covers your build &amp; launch. This plan is just for people who want hands-off peace of mind.</p>
+      <p class="small"><strong>Site Steward+ — $199/yr</strong> (includes 1 domain renewal)</p>
+    </div>
   </div>
   <div class="guarantee" style="margin-top:16px">
     <strong>Our Guarantee:</strong> If I miss the launch window on my side → <strong>20% off</strong> the balance.
@@ -237,6 +249,10 @@
       <summary>How do payments work?</summary>
       <p>$50 deposit to hold the weekend; balance on launch via Square. PA clients: development is taxable when transferred.</p>
     </details>
+    <details class="card" style="padding:12px">
+      <summary>Is there a monthly fee?</summary>
+      <p>No. $499 is flat for your 48-hour build and launch. After launch, you can DIY everything (I give you the handoff doc), or choose an optional Site Steward plan if you want me to keep an eye on renewals, DNS/SSL, and tiny tweaks.</p>
+    </details>
   </div>
 </section>
 
@@ -297,7 +313,9 @@
     {"@type":"Question","name":"What do you need from me to start?",
      "acceptedAnswer":{"@type":"Answer","text":"Logo or name, brand color, services, hours, address, and 3–6 photos."}},
     {"@type":"Question","name":"How do payments work?",
-     "acceptedAnswer":{"@type":"Answer","text":"$50 deposit to hold the weekend; balance on launch via Square. PA clients: development is taxable when transferred."}}
+     "acceptedAnswer":{"@type":"Answer","text":"$50 deposit to hold the weekend; balance on launch via Square. PA clients: development is taxable when transferred."}},
+    {"@type":"Question","name":"Is there a monthly fee?",
+     "acceptedAnswer":{"@type":"Answer","text":"No. $499 is flat for your 48-hour build and launch. After launch, you can DIY everything (I give you the handoff doc), or choose an optional Site Steward plan if you want me to keep an eye on renewals, DNS/SSL, and tiny tweaks."}}
   ]
 }
 </script>


### PR DESCRIPTION
## Summary
- add optional Site Steward care plan card in pricing
- include FAQ entry about monthly fees and structured data update

## Testing
- `npx --yes html-validate index.html`
- `npx --yes html-validate index.html privacy.html` *(fails: privacy.html doctype/void-style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7a86b80c833192d2d929fcd4e274