### PR TITLE
Add catalog-style add-ons section

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "block-no-empty": true
+  }
+}

--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
 <section id="pricing" class="container" style="padding:32px 0">
   <h2>Simple, Transparent Pricing</h2>
   <p class="lead">No hourly surprises. No hidden fees. You own everything.</p>
-  <div class="grid cols-3" style="align-items:start;margin-top:12px">
+  <div class="grid cols-2" style="align-items:start;margin-top:12px">
     <div class="tile g-blue-purple card-lg">
       <div class="kicker" style="color:#E6E6FF">Complete One-Page Website</div>
       <div style="font-size:40px;font-weight:800;margin:10px 0">$499</div>
@@ -160,17 +160,7 @@
       </ul>
       <div class="badge" style="margin-top:10px">Small, non-refundable deposit to hold your weekend</div>
     </div>
-    <div class="card" style="padding:16px">
-      <div class="kicker">Custom Domain Setup — $50</div>
-      <p>Point your domain, SSL, and email forwarders handled.</p>
-      <ul class="list"><li>✔ DNS + HTTPS</li><li>✔ Email forwarder</li></ul>
-    </div>
-    <div class="card" style="padding:16px">
-      <div class="kicker">Photo Pass — $50</div>
-      <p>Optimize up to 10 photos for speed and clarity.</p>
-      <ul class="list"><li>✔ Compress &amp; crop</li><li>✔ Color/contrast tune</li></ul>
-    </div>
-    <div class="card" style="padding:16px">
+    <div class="card">
       <div class="kicker">Optional Care (no contract)</div>
       <p style="font-weight:600;margin:6px 0">Site Steward — $149/yr <span class="small">(or $19/mo)</span></p>
       <ul class="list">
@@ -185,6 +175,29 @@
   </div>
   <div class="guarantee" style="margin-top:16px">
     <strong>Our Guarantee:</strong> If I miss the launch window on my side → <strong>20% off</strong> the balance.
+  </div>
+</section>
+
+<section id="addons" class="section">
+  <div class="container">
+    <h2>Optional Add-Ons</h2>
+    <div class="grid cols-3">
+      <article class="card">
+        <h3>Custom Domain Setup</h3>
+        <p>$50 — DNS, SSL, email forwarders.</p>
+        <a class="pill" href="#book">Add at checkout →</a>
+      </article>
+      <article class="card">
+        <h3>Photo Pass</h3>
+        <p>$50 — compress, crop, color tune 10 photos.</p>
+        <a class="pill" href="#book">Add at checkout →</a>
+      </article>
+      <article class="card">
+        <h3>Restaurant Lite</h3>
+        <p>Pickup ordering (PayPal), ≤12 items.</p>
+        <a class="pill" href="#restaurant">See demo →</a>
+      </article>
+    </div>
   </div>
 </section>
 

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 :root{
   --max:1120px; --r:18px; --r-lg:22px;
-  --sh:0 8px 28px rgba(16,24,40,.12);
+  --sh:0 8px 28px rgba(16,24,40,.10);
   --bg:#F7FAFF; --ink:#0B1220; --ink-2:#3C4A67; --muted:#E6EEF8;
   --brand:#3B82F6; --brand-2:#8B5CF6; --success:#22C55E; --success-bg:#ECFDF5;
   --mobile-sticky-space:100px;
@@ -20,7 +20,8 @@ h2{font-size:28px;margin:6px 0 12px}
 .cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}
 @media (max-width:900px){.cols-2,.cols-3{grid-template-columns:1fr}}
 
-.card{background:#fff;border-radius:var(--r);box-shadow:var(--sh);border:1px solid #EEF2F7}
+.card{background:#fff;border-radius:var(--r);box-shadow:var(--sh);border:1px solid #EAF0F7;padding:16px}
+.card h3{margin:4px 0 8px}
 .card-lg{border-radius:var(--r-lg)}
 .tile{color:#fff;border-radius:var(--r);box-shadow:var(--sh);padding:18px}
 .g-blue-purple{background:linear-gradient(135deg,#3B82F6 0%,#8B5CF6 100%)}


### PR DESCRIPTION
## Summary
- Split pricing and optional extras by adding a dedicated add-ons section with product-style cards
- Simplify pricing grid to main package plus optional care plan
- Lighten card shadow and add default padding and heading spacing

## Testing
- `npx -y htmlhint index.html`
- `npx -y stylelint styles.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb88461a48331827dfc330a70c419