### PR TITLE
Add catalog-style add-ons section

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "block-no-empty": true
+  }
+}


### PR DESCRIPTION
## Summary
- Split pricing and optional extras by adding a dedicated add-ons section with product-style cards
- Simplify pricing grid to main package plus optional care plan
- Lighten card shadow and add default padding and heading spacing
- Add basic stylelint configuration so CSS linting runs

## Testing
- `npx -y htmlhint index.html`
- `npx -y stylelint styles.css`


------
https://chatgpt.com/codex/tasks/task_e_68bbb98e33cc83318da2756a75b4dd56