### PR TITLE
feat: alternate section bands and repeat CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,16 +73,19 @@
   <a class="btn btn-outline" href="tel:18145808040">Call/Text</a>
 </div>
 
-<section class="container" style="padding:48px 0 24px">
-  <h1>Your website, live by Monday — $499 flat.</h1>
-  <p class="lead">Book Friday, build Saturday, launch Sunday. No bloated scope, no hourly surprises.</p>
-  <div style="display:flex;gap:10px;margin-top:12px">
-    <a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Book free fit check</a>
-    <a class="btn btn-outline" href="https://square.link/u/JCKqtjo5" target="_blank" rel="noopener">Pay $50 deposit</a>
+<section class="alt-band">
+  <div class="container" style="padding:48px 0 24px">
+    <h1>Your website, live by Monday — $499 flat.</h1>
+    <p class="lead">Book Friday, build Saturday, launch Sunday. No bloated scope, no hourly surprises.</p>
+    <div style="display:flex;gap:10px;margin-top:12px">
+      <a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Book free fit check</a>
+      <a class="btn btn-outline" href="https://square.link/u/JCKqtjo5" target="_blank" rel="noopener">Pay $50 deposit</a>
+    </div>
+    <p class="alt-band-cta"><a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Book free fit check</a></p>
   </div>
 </section>
 
-<section class="section">
+<section class="alt-band">
   <div class="container">
     <div class="band band--angled">
       <div class="eyebrow">How it works</div>
@@ -112,14 +115,16 @@
         </div>
       </div>
     </div>
+    <p class="alt-band-cta"><a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Book free fit check</a></p>
   </div>
 </section>
 
 
-<section id="work" class="container" style="padding:32px 0">
-  <h2>Real Local Work</h2>
-  <p class="lead">Trusted by small businesses around Erie/Lake City, PA.</p>
-  <div class="grid cols-3" style="margin-top:12px">
+<section id="work" class="alt-band">
+  <div class="container" style="padding:32px 0">
+    <h2>Real Local Work</h2>
+    <p class="lead">Trusted by small businesses around Erie/Lake City, PA.</p>
+    <div class="grid cols-3" style="margin-top:12px">
     <article class="tile g-indigo-blue">
       <div class="kicker" style="color:#CFE2FF">Integrity EV Solutions</div>
       <p style="margin:6px 0 10px">Professional EV charging site with simple service options, quote, and contact flow.</p>
@@ -138,44 +143,49 @@
       <p style="margin:6px 0 10px">Straightforward services and “request a quote” flow for a regional fleet.</p>
       <a class="pill" href="https://www.wileytrucking.com" target="_blank" rel="noopener">View site →</a>
     </article>
+    </div>
+    <p class="alt-band-cta"><a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Book free fit check</a></p>
   </div>
 </section>
 
-<section id="pricing" class="container" style="padding:32px 0">
-  <h2>Simple, Transparent Pricing</h2>
-  <p class="lead">No hourly surprises. No hidden fees. You own everything.</p>
-  <div class="grid cols-2" style="align-items:start;margin-top:12px">
-    <div class="tile g-blue-purple card-lg">
-      <div class="kicker" style="color:#E6E6FF">Complete One-Page Website</div>
-      <div style="font-size:40px;font-weight:800;margin:10px 0">$499</div>
-      <ul class="list">
-        <li>✔ Mobile-first design</li>
-        <li>✔ Copy polish &amp; CTA</li>
-        <li>✔ Domain &amp; Google indexing</li>
-        <li>✔ 2 image swaps</li>
-        <li>✔ No monthly fees required</li>
-      </ul>
-      <div class="badge" style="margin-top:10px">Small, non-refundable deposit to hold your weekend</div>
+<section id="pricing" class="alt-band">
+  <div class="container" style="padding:32px 0">
+    <h2>Simple, Transparent Pricing</h2>
+    <p class="lead">No hourly surprises. No hidden fees. You own everything.</p>
+    <div class="grid cols-2" style="align-items:start;margin-top:12px">
+      <div class="tile g-blue-purple card-lg">
+        <div class="kicker" style="color:#E6E6FF">Complete One-Page Website</div>
+        <div style="font-size:40px;font-weight:800;margin:10px 0">$499</div>
+        <ul class="list">
+          <li>✔ Mobile-first design</li>
+          <li>✔ Copy polish &amp; CTA</li>
+          <li>✔ Domain &amp; Google indexing</li>
+          <li>✔ 2 image swaps</li>
+          <li>✔ No monthly fees required</li>
+        </ul>
+        <div class="badge" style="margin-top:10px">Small, non-refundable deposit to hold your weekend</div>
+      </div>
+      <div class="card">
+        <div class="kicker">Optional Care (no contract)</div>
+        <p style="font-weight:600;margin:6px 0">Site Steward — $149/yr <span class="small">(or $19/mo)</span></p>
+        <ul class="list">
+          <li>✔ We keep DNS &amp; SSL current</li>
+          <li>✔ Renewal reminders (I’ll press the button)</li>
+          <li>✔ Quarterly checkup (links/phone/booking)</li>
+          <li>✔ 1 tiny update/quarter</li>
+        </ul>
+        <p class="small">$499 covers your build &amp; launch. This plan is just for people who want hands-off peace of mind.</p>
+        <p class="small"><strong>Site Steward+ — $199/yr</strong> (includes 1 domain renewal)</p>
+      </div>
     </div>
-    <div class="card">
-      <div class="kicker">Optional Care (no contract)</div>
-      <p style="font-weight:600;margin:6px 0">Site Steward — $149/yr <span class="small">(or $19/mo)</span></p>
-      <ul class="list">
-        <li>✔ We keep DNS &amp; SSL current</li>
-        <li>✔ Renewal reminders (I’ll press the button)</li>
-        <li>✔ Quarterly checkup (links/phone/booking)</li>
-        <li>✔ 1 tiny update/quarter</li>
-      </ul>
-      <p class="small">$499 covers your build &amp; launch. This plan is just for people who want hands-off peace of mind.</p>
-      <p class="small"><strong>Site Steward+ — $199/yr</strong> (includes 1 domain renewal)</p>
+    <div class="guarantee" style="margin-top:16px">
+      <strong>Our Guarantee:</strong> If I miss the launch window on my side → <strong>20% off</strong> the balance.
     </div>
-  </div>
-  <div class="guarantee" style="margin-top:16px">
-    <strong>Our Guarantee:</strong> If I miss the launch window on my side → <strong>20% off</strong> the balance.
+    <p class="alt-band-cta"><a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Book free fit check</a></p>
   </div>
 </section>
 
-<section id="addons" class="section">
+<section id="addons" class="alt-band">
   <div class="container">
     <h2>Optional Add-Ons</h2>
     <div class="grid cols-3">
@@ -195,87 +205,98 @@
         <a class="pill" href="#restaurant">See demo →</a>
       </article>
     </div>
+    <p class="alt-band-cta"><a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Book free fit check</a></p>
   </div>
 </section>
 
-<section id="perfect" class="container" style="padding:32px 0">
-  <h2>🎯 Perfect For</h2>
-  <ul class="grid cols-3" style="margin-top:12px;padding-left:0">
-    <li class="pill">💈 Barbers &amp; salons</li>
-    <li class="pill">🛍️ Thrift &amp; vintage shops</li>
-    <li class="pill">🌿 Lawn care &amp; landscaping</li>
-    <li class="pill">⛪ Churches &amp; boosters</li>
-    <li class="pill">🧵 Etsy &amp; makers</li>
-    <li class="pill">📍 Local services</li>
-  </ul>
+<section id="perfect" class="alt-band">
+  <div class="container" style="padding:32px 0">
+    <h2>🎯 Perfect For</h2>
+    <ul class="grid cols-3" style="margin-top:12px;padding-left:0">
+      <li class="pill">💈 Barbers &amp; salons</li>
+      <li class="pill">🛍️ Thrift &amp; vintage shops</li>
+      <li class="pill">🌿 Lawn care &amp; landscaping</li>
+      <li class="pill">⛪ Churches &amp; boosters</li>
+      <li class="pill">🧵 Etsy &amp; makers</li>
+      <li class="pill">📍 Local services</li>
+    </ul>
+    <p class="alt-band-cta"><a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Book free fit check</a></p>
+  </div>
 </section>
 
-<section id="book" class="container" style="padding:32px 0">
-  <div class="card" style="padding:18px">
-    <div class="kicker">Get started</div>
-    <h2 style="margin:6px 0 12px">Book a free 15-minute fit check</h2>
-    <p class="lead">Pick a slot and include a link to any existing socials so I can match the look.</p>
-    <div style="display:flex;flex-wrap:wrap;gap:10px;margin:12px 0">
-      <a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Open booking link</a>
-      <a class="btn btn-outline" href="https://square.link/u/JCKqtjo5" target="_blank" rel="noopener" id="pay-deposit">Pay $50 deposit</a>
-      <a class="btn btn-outline" href="https://square.link/u/24s8uLsE" target="_blank" rel="noopener" id="pay-balance">Pay $449 launch balance (plus tax*)</a>
+<section id="book" class="alt-band">
+  <div class="container" style="padding:32px 0">
+    <div class="card" style="padding:18px">
+      <div class="kicker">Get started</div>
+      <h2 style="margin:6px 0 12px">Book a free 15-minute fit check</h2>
+      <p class="lead">Pick a slot and include a link to any existing socials so I can match the look.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;margin:12px 0">
+        <a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Open booking link</a>
+        <a class="btn btn-outline" href="https://square.link/u/JCKqtjo5" target="_blank" rel="noopener" id="pay-deposit">Pay $50 deposit</a>
+        <a class="btn btn-outline" href="https://square.link/u/24s8uLsE" target="_blank" rel="noopener" id="pay-balance">Pay $449 launch balance (plus tax*)</a>
+      </div>
+      <p><strong>Prefer to call or email?</strong><br>
+        Call or text <a href="tel:18145808040">814‑580‑8040</a> ·
+        Email <a href="mailto:jordanlander@gmail.com?subject=One‑Weekend%20Websites%20Fit%20Check">jordanlander@gmail.com</a>
+      </p>
+      <p class="small">*PA clients: Website development is taxable when the site is transferred to you (files/repo/ownership). Hosting/domain configuration/support listed separately is non-taxable.</p>
     </div>
-    <p><strong>Prefer to call or email?</strong><br>
-      Call or text <a href="tel:18145808040">814‑580‑8040</a> ·
-      Email <a href="mailto:jordanlander@gmail.com?subject=One‑Weekend%20Websites%20Fit%20Check">jordanlander@gmail.com</a>
-    </p>
-    <p class="small">*PA clients: Website development is taxable when the site is transferred to you (files/repo/ownership). Hosting/domain configuration/support listed separately is non-taxable.</p>
+    <p class="alt-band-cta"><a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Book free fit check</a></p>
   </div>
 </section>
 
-<section id="contact" class="container" style="padding:32px 0">
-  <div class="card" style="padding:18px">
-    <div class="kicker">Contact</div>
-    <h2 style="margin:6px 0 12px">Send a quick message</h2>
-    <form action="https://formsubmit.co/jordanlander@gmail.com" method="POST">
-      <input type="hidden" name="_subject" value="One‑Weekend Websites — New inquiry">
-      <input type="hidden" name="_template" value="table">
-      <input type="hidden" name="_next" value="https://www.oneweekendwebsites.com/#thanks">
-      <input type="text" name="_honey" style="display:none" tabindex="-1" autocomplete="off">
-      <div class="grid cols-2" style="margin-top:8px">
-        <div>
-          <label for="name" class="small">Name</label>
-          <input id="name" name="name" type="text" required>
+<section id="contact" class="alt-band">
+  <div class="container" style="padding:32px 0">
+    <div class="card" style="padding:18px">
+      <div class="kicker">Contact</div>
+      <h2 style="margin:6px 0 12px">Send a quick message</h2>
+      <form action="https://formsubmit.co/jordanlander@gmail.com" method="POST">
+        <input type="hidden" name="_subject" value="One‑Weekend Websites — New inquiry">
+        <input type="hidden" name="_template" value="table">
+        <input type="hidden" name="_next" value="https://www.oneweekendwebsites.com/#thanks">
+        <input type="text" name="_honey" style="display:none" tabindex="-1" autocomplete="off">
+        <div class="grid cols-2" style="margin-top:8px">
+          <div>
+            <label for="name" class="small">Name</label>
+            <input id="name" name="name" type="text" required>
+          </div>
+          <div>
+            <label for="email" class="small">Email</label>
+            <input id="email" name="email" type="email" required>
+          </div>
         </div>
-        <div>
-          <label for="email" class="small">Email</label>
-          <input id="email" name="email" type="email" required>
+        <div class="grid cols-2" style="margin-top:8px">
+          <div>
+            <label for="phone" class="small">Phone (optional)</label>
+            <input id="phone" name="phone" type="tel">
+          </div>
+          <div>
+            <label for="business" class="small">Business / Org (optional)</label>
+            <input id="business" name="business" type="text">
+          </div>
         </div>
-      </div>
-      <div class="grid cols-2" style="margin-top:8px">
-        <div>
-          <label for="phone" class="small">Phone (optional)</label>
-          <input id="phone" name="phone" type="tel">
+        <div style="margin-top:8px">
+          <label for="message" class="small">Message</label>
+          <textarea id="message" name="message" rows="4" required></textarea>
         </div>
-        <div>
-          <label for="business" class="small">Business / Org (optional)</label>
-          <input id="business" name="business" type="text">
+        <div style="display:flex;flex-wrap:wrap;gap:10px;margin-top:12px;align-items:center">
+          <button class="btn btn-primary" type="submit">Send message</button>
+          <span class="small" style="color:var(--ink-2)">Or call/text <a href="tel:18145808040">814‑580‑8040</a></span>
         </div>
+      </form>
+      <div id="thanks" class="small" style="display:none;margin-top:12px;color:var(--success)">
+        ✅ Thanks! Your message was sent. I’ll reply shortly.
       </div>
-      <div style="margin-top:8px">
-        <label for="message" class="small">Message</label>
-        <textarea id="message" name="message" rows="4" required></textarea>
-      </div>
-      <div style="display:flex;flex-wrap:wrap;gap:10px;margin-top:12px;align-items:center">
-        <button class="btn btn-primary" type="submit">Send message</button>
-        <span class="small" style="color:var(--ink-2)">Or call/text <a href="tel:18145808040">814‑580‑8040</a></span>
-      </div>
-    </form>
-    <div id="thanks" class="small" style="display:none;margin-top:12px;color:var(--success)">
-      ✅ Thanks! Your message was sent. I’ll reply shortly.
+      <p class="small" style="margin-top:10px;color:var(--ink-2)">This form uses FormSubmit (free). We never sell your info. For faster replies, include your link(s) and ideal launch weekend.</p>
     </div>
-    <p class="small" style="margin-top:10px;color:var(--ink-2)">This form uses FormSubmit (free). We never sell your info. For faster replies, include your link(s) and ideal launch weekend.</p>
+    <p class="alt-band-cta"><a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Book free fit check</a></p>
   </div>
 </section>
 
-<section id="faq" class="container" style="padding:32px 0">
-  <h2>FAQ</h2>
-  <div class="grid" style="margin-top:12px">
+<section id="faq" class="alt-band">
+  <div class="container" style="padding:32px 0">
+    <h2>FAQ</h2>
+    <div class="grid" style="margin-top:12px">
     <details class="card" style="padding:12px">
       <summary>What do you need from me to start?</summary>
       <p>Logo or name, brand color, services, hours, address, and 3–6 photos.</p>
@@ -288,6 +309,8 @@
       <summary>Is there a monthly fee?</summary>
       <p>No. $499 is flat for your 48-hour build and launch. After launch, you can DIY everything (I give you the handoff doc), or choose an optional Site Steward plan if you want me to keep an eye on renewals, DNS/SSL, and tiny tweaks.</p>
     </details>
+    </div>
+    <p class="alt-band-cta"><a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Book free fit check</a></p>
   </div>
 </section>
 

--- a/styles.css
+++ b/styles.css
@@ -5,11 +5,15 @@
   --brand:#3B82F6; --brand-2:#8B5CF6; --success:#22C55E; --success-bg:#ECFDF5;
   --mobile-sticky-space:100px;
 }
-body{background:var(--bg);color:var(--ink);font:16px/1.55 ui-sans-serif,system-ui,Segoe UI,Inter,Arial;margin:0}
+body{background:#fff;color:var(--ink);font:16px/1.55 ui-sans-serif,system-ui,Segoe UI,Inter,Arial;margin:0}
 .container{max-width:var(--max);margin:auto;padding:0 20px}
 h1{font-size:40px;line-height:1.1;margin:8px 0 12px}
-h2{font-size:28px;margin:6px 0 12px}
+h2{font-size:32px;margin:6px 0 12px}
 .lead{color:var(--ink-2);font-size:18px}
+section.alt-band:nth-of-type(odd){background:#fff}
+section.alt-band:nth-of-type(even){background:var(--bg)}
+.alt-band-cta{text-align:center;margin-top:24px}
+section p{color:var(--ink-2)}
 .section{padding:48px 0}
 .band{background:linear-gradient(135deg,#3B82F6 0%,#8B5CF6 100%);color:#fff;border-radius:var(--r);box-shadow:var(--sh);padding:22px}
 .band--angled{position:relative;overflow:hidden}
@@ -31,7 +35,7 @@ h2{font-size:28px;margin:6px 0 12px}
 
 .badge{display:inline-flex;align-items:center;gap:8px;padding:8px 12px;border-radius:999px;background:#fff;color:var(--ink-2);border:1px solid #E5EDF7}
 .pill{display:inline-block;padding:8px 12px;border-radius:999px;border:1px solid #CFE1FF;background:#F5F9FF;color:#2357D9;text-decoration:none}
-.btn{display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:12px;border:1px solid #2156E8;cursor:pointer;text-decoration:none;font-weight:600}
+.btn{display:inline-flex;align-items:center;justify-content:center;padding:12px 20px;border-radius:12px;border:1px solid #2156E8;cursor:pointer;text-decoration:none;font-weight:600;font-size:16px}
 .btn-primary{background:var(--brand);color:#fff;border-color:var(--brand)}
 .btn-outline{background:#fff;color:#1F46C9}
 .btn:hover{transform:translateY(-1px)}


### PR DESCRIPTION
## Summary
- alternate section backgrounds between white and light blue
- repeat "Book free fit check" call-to-action after each band
- enlarge section headings and buttons for clearer hierarchy

## Testing
- `npm test` *(fails: no package.json)*
- `xmllint --html -noout index.html` *(fails: HTML5 tags not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb5d5073c8331bfbbdfdc1d440fc1