### PR TITLE
Add subtle transition effects for interactive elements

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -30,11 +30,12 @@ h2{font-size:28px;margin:6px 0 12px}
 .g-green{background:linear-gradient(135deg,#10B981 0%,#22C55E 100%)}
 
 .badge{display:inline-flex;align-items:center;gap:8px;padding:8px 12px;border-radius:999px;background:#fff;color:var(--ink-2);border:1px solid #E5EDF7}
-.pill{display:inline-block;padding:8px 12px;border-radius:999px;border:1px solid #CFE1FF;background:#F5F9FF;color:#2357D9;text-decoration:none}
-.btn{display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:12px;border:1px solid #2156E8;cursor:pointer;text-decoration:none;font-weight:600}
+.pill{display:inline-block;padding:8px 12px;border-radius:999px;border:1px solid #CFE1FF;background:#F5F9FF;color:#2357D9;text-decoration:none;transition:background-color .2s ease,color .2s ease,box-shadow .2s ease,transform .2s ease}
+.pill:hover{transform:translateY(-1px);box-shadow:0 4px 12px rgba(16,24,40,.08)}
+.btn{display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:12px;border:1px solid #2156E8;cursor:pointer;text-decoration:none;font-weight:600;transition:background-color .2s ease,color .2s ease,box-shadow .2s ease,transform .2s ease}
 .btn-primary{background:var(--brand);color:#fff;border-color:var(--brand)}
 .btn-outline{background:#fff;color:#1F46C9}
-.btn:hover{transform:translateY(-1px)}
+.btn:hover{transform:translateY(-1px);box-shadow:0 4px 12px rgba(16,24,40,.08)}
 .btn:focus-visible{outline:3px solid #60A5FA;outline-offset:2px}
 .kicker{font-weight:700;color:#5B6B91;text-transform:uppercase;letter-spacing:.04em;font-size:12px}
 
@@ -56,11 +57,14 @@ h2{font-size:28px;margin:6px 0 12px}
 /* Desktop nav */
 .site-nav{display:block}
 .nav-list{display:flex;gap:12px;align-items:center;margin:0;padding:0;list-style:none}
+.nav-list a{transition:background-color .2s ease,color .2s ease}
+.nav-list a:hover{background:var(--muted)}
 .nav-cta a.btn-primary{padding:10px 14px;border-radius:12px}
 
 /* Mobile toggle */
 .nav-toggle{display:none;align-items:center;justify-content:center;
-  width:44px;height:44px;border-radius:10px;border:1px solid #CFE1FF;background:#fff}
+  width:44px;height:44px;border-radius:10px;border:1px solid #CFE1FF;background:#fff;transition:background-color .2s ease,transform .2s ease}
+.nav-toggle:hover{background:#F5F9FF}
 .nav-toggle:focus-visible{outline:3px solid #60A5FA;outline-offset:2px}
 .nav-toggle .bars{display:inline-block;width:20px;height:2px;background:#0b1220;position:relative}
 .nav-toggle .bars::before,.nav-toggle .bars::after{content:"";position:absolute;left:0;width:20px;height:2px;background:#0b1220}
@@ -90,7 +94,7 @@ h2{font-size:28px;margin:6px 0 12px}
 /* Auto-hide behavior */
 .site-header.autohide--up{transform:translateY(-100%);transition:transform .2s ease}
 @media (prefers-reduced-motion: reduce){
-  .site-nav,.nav-backdrop,.site-header{transition:none}
+  .site-nav,.nav-backdrop,.site-header,.btn,.pill,.nav-toggle,.nav-list a{transition:none}
 }
 
 /* Avoid anchor being hidden by sticky header */


### PR DESCRIPTION
## Summary
- Smooth hover transitions for buttons and pills with slight lift and shadow
- Add background fade and hover styling for navigation links and mobile toggle
- Disable transitions when `prefers-reduced-motion` is enabled for accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb9a0d42483319575248e93c27b52