### PR TITLE
Ensure legible text in gradient tiles and bands

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,7 @@ h2{font-size:32px;margin:6px 0 12px}
 section.alt-band:nth-of-type(odd){background:#fff}
 section.alt-band:nth-of-type(even){background:var(--bg)}
 section p{color:var(--ink-2)}
+.band p,.tile p{color:inherit}
 .section{padding:48px 0}
 .band{background:linear-gradient(135deg,#3B82F6 0%,#8B5CF6 100%);color:#fff;border-radius:var(--r);box-shadow:var(--sh);padding:22px}
 .band--angled{position:relative;overflow:hidden}


### PR DESCRIPTION
## Summary
- Prevent global `section p` style from darkening text inside gradient bands and tiles
- Allow paragraphs in `.band` and `.tile` to inherit their parent color (white)

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbd1d89948331a2a5983a3f47c314