### PR TITLE
Expand checkout options and update two‑day window copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>One‑Weekend Websites — Launch‑Ready in 48 Hours | Jordan Lander</title>
-  <meta name="description" content="Productized website build: Launch‑ready, mobile‑first, affordable one‑page sites for local businesses in 48 hours. Flat $499. Optional domain setup + photo pass. Book a free 15‑minute fit check.">
+  <meta name="description" content="Productized website build: Launch‑ready, mobile‑first, affordable one‑page sites for local businesses in 48 hours. Flat $499. Optional domain setup, photo pass, and annual care. Book a free 15‑minute fit check.">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#ffffff">
 
@@ -24,6 +24,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>⚡</text></svg>">
   <link rel="preconnect" href="https://cal.com">
   <link rel="preconnect" href="https://square.link">
+  <link rel="preconnect" href="https://checkout.square.site">
   <link rel="stylesheet" href="styles.css">
 
   <!-- Google tag (gtag.js) -->
@@ -75,11 +76,13 @@
 
 <section class="alt-band">
   <div class="container" style="padding:48px 0 24px">
-    <h1>Your website, live by Monday — $499 flat.</h1>
-    <p class="lead">Book Friday, build Saturday, launch Sunday. No bloated scope, no hourly surprises.</p>
-    <div style="display:flex;gap:10px;margin-top:12px">
-      <a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Book free fit check</a>
+    <h1>Your website, live in 48 hours — $499 flat.</h1>
+    <p class="lead">Launch-ready in 48 hours. Pick any two-day window—no hourly surprises.</p>
+    <div class="cta-row" style="display:flex;gap:10px;flex-wrap:wrap;margin-top:12px">
+      <a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15">Book free fit check</a>
       <a class="btn btn-outline" href="https://square.link/u/JCKqtjo5" target="_blank" rel="noopener">Pay $50 deposit</a>
+      <a class="btn" href="https://square.link/u/u08vlvAR" target="_blank" rel="noopener">Pay in full + choose add-ons →</a>
+      <a class="pill" href="https://square.link/u/wL2hwxEx" target="_blank" rel="noopener">Subscribe to Care (monthly)</a>
     </div>
   </div>
 </section>
@@ -89,25 +92,25 @@
     <div class="band band--angled">
       <div class="eyebrow">How it works</div>
       <h2 style="margin:6px 0 10px">Launch in 48 hours</h2>
-      <p>Book Friday, build Saturday, launch Sunday.</p>
+      <p>Pick any two-day window. Day 1: build &amp; preview → Day 2: launch to your domain.</p>
     </div>
     <div class="card card-lg" style="padding:16px;margin-top:32px">
       <div class="kicker">Simple 3-Step Process</div>
       <div class="grid" id="process">
         <div class="card" style="padding:12px">
-          <div style="display:flex;gap:10px;align-items:center"><span class="icon-num">1</span><strong>Friday: Book &amp; Plan</strong></div>
+          <div style="display:flex;gap:10px;align-items:center"><span class="icon-num">1</span><strong>Book &amp; Plan</strong></div>
           <ul class="list">
             <li>✔ Fit check (15m)</li><li>✔ Deposit</li><li>✔ Send logo, services, photos</li>
           </ul>
         </div>
         <div class="card" style="padding:12px">
-          <div style="display:flex;gap:10px;align-items:center"><span class="icon-num">2</span><strong>Saturday: Build Day</strong></div>
+          <div style="display:flex;gap:10px;align-items:center"><span class="icon-num">2</span><strong>Day 1: Build &amp; Preview</strong></div>
           <ul class="list">
             <li>✔ Clean, mobile-first page</li><li>✔ Copy polish</li><li>✔ Preview link</li>
           </ul>
         </div>
         <div class="card" style="padding:12px">
-          <div style="display:flex;gap:10px;align-items:center"><span class="icon-num">3</span><strong>Sunday: Launch</strong></div>
+          <div style="display:flex;gap:10px;align-items:center"><span class="icon-num">3</span><strong>Day 2: Launch</strong></div>
           <ul class="list">
             <li>✔ Live on your domain</li><li>✔ Google indexing</li><li>✔ 2 image swaps post-launch</li>
           </ul>
@@ -123,24 +126,27 @@
     <h2>Real Local Work</h2>
     <p class="lead">Trusted by small businesses around Erie/Lake City, PA.</p>
     <div class="grid cols-3" style="margin-top:12px">
-    <article class="tile g-indigo-blue">
-      <div class="kicker" style="color:#CFE2FF">Integrity EV Solutions</div>
-      <p style="margin:6px 0 10px">Professional EV charging site with simple service options, quote, and contact flow.</p>
-      <a class="pill" href="https://www.integrityevsolutions.com" target="_blank" rel="noopener">View site →</a>
-      <div style="margin-top:12px;display:flex;align-items:center;gap:6px">
-        ⭐⭐⭐⭐⭐ <span style="opacity:.9">“Site + Google Ads boosted monthly installs.” — Integrity EV</span>
-      </div>
-    </article>
-    <article class="tile g-pink-purple">
-      <div class="kicker" style="color:#FFE5F6">Girard Arts</div>
-      <p style="margin:6px 0 10px">Vibrant community showcase with event sign-ups, donate, and contact.</p>
-      <a class="pill" href="https://girardarts.org" target="_blank" rel="noopener">View site →</a>
-    </article>
-    <article class="tile g-green">
-      <div class="kicker" style="color:#E6FFEF">Wiley Trucking</div>
-      <p style="margin:6px 0 10px">Straightforward services and “request a quote” flow for a regional fleet.</p>
-      <a class="pill" href="https://www.wileytrucking.com" target="_blank" rel="noopener">View site →</a>
-    </article>
+      <article class="card">
+        <img src="/work-integrity-ev.jpg" alt="Integrity EV preview" width="600" height="360" loading="lazy" style="width:100%;height:auto;border-radius:var(--r)">
+        <div class="kicker">Integrity EV Solutions</div>
+        <p style="margin:6px 0 10px">Professional EV charging site with simple service options, quote, and contact flow.</p>
+        <a class="pill" href="https://www.integrityevsolutions.com" target="_blank" rel="noopener">View site →</a>
+        <div style="margin-top:12px;display:flex;align-items:center;gap:6px">
+          ⭐⭐⭐⭐⭐ <span style="opacity:.9">“Site + Google Ads boosted monthly installs.” — Integrity EV</span>
+        </div>
+      </article>
+      <article class="card">
+        <img src="/work-girard-arts.jpg" alt="Girard Arts preview" width="600" height="360" loading="lazy" style="width:100%;height:auto;border-radius:var(--r)">
+        <div class="kicker">Girard Arts</div>
+        <p style="margin:6px 0 10px">Vibrant community showcase with event sign-ups, donate, and contact.</p>
+        <a class="pill" href="https://girardarts.org" target="_blank" rel="noopener">View site →</a>
+      </article>
+      <article class="card">
+        <img src="/work-wiley-trucking.jpg" alt="Wiley Trucking preview" width="600" height="360" loading="lazy" style="width:100%;height:auto;border-radius:var(--r)">
+        <div class="kicker">Wiley Trucking</div>
+        <p style="margin:6px 0 10px">Straightforward services and “request a quote” flow for a regional fleet.</p>
+        <a class="pill" href="https://www.wileytrucking.com" target="_blank" rel="noopener">View site →</a>
+      </article>
     </div>
   </div>
 </section>
@@ -160,7 +166,7 @@
           <li>✔ 2 image swaps</li>
           <li>✔ No monthly fees required</li>
         </ul>
-        <div class="badge" style="margin-top:10px">Small, non-refundable deposit to hold your weekend</div>
+        <div class="badge" style="margin-top:10px">Small, non-refundable deposit to hold your build window</div>
       </div>
       <div class="card">
         <div class="kicker">Optional Care (no contract)</div>
@@ -175,31 +181,21 @@
         <p class="small"><strong>Site Steward+ — $199/yr</strong> (includes 1 domain renewal)</p>
       </div>
     </div>
+    <div class="cta-row" style="display:flex;gap:10px;flex-wrap:wrap;margin-top:12px">
+      <a class="btn btn-primary" href="https://square.link/u/u08vlvAR" target="_blank" rel="noopener">Pay in full + choose add-ons</a>
+      <a class="btn btn-outline" href="https://square.link/u/JCKqtjo5" target="_blank" rel="noopener">Reserve with $50 deposit</a>
+      <a class="pill" href="https://square.link/u/wL2hwxEx" target="_blank" rel="noopener">Subscribe to Care (monthly)</a>
+    </div>
+    <div style="margin-top:12px">
+      <div class="kicker">Optional add-ons (choose at checkout)</div>
+      <ul class="list">
+        <li>Custom domain setup (+$50)</li>
+        <li>Photo pass (+$50)</li>
+        <li>Care — Annual (prepay) (+$99) — 12 months of care (DNS/HTTPS stewardship, light uptime watch, monthly check-ins, 30 min/month content updates). (Monthly option available via separate subscription button.)</li>
+      </ul>
+    </div>
     <div class="guarantee" style="margin-top:16px">
       <strong>Our Guarantee:</strong> If I miss the launch window on my side → <strong>20% off</strong> the balance.
-    </div>
-  </div>
-</section>
-
-<section id="addons" class="alt-band">
-  <div class="container">
-    <h2>Optional Add-Ons</h2>
-    <div class="grid cols-3">
-      <article class="card">
-        <h3>Custom Domain Setup</h3>
-        <p>$50 — DNS, SSL, email forwarders.</p>
-        <a class="pill" href="#book">Add at checkout →</a>
-      </article>
-      <article class="card">
-        <h3>Photo Pass</h3>
-        <p>$50 — compress, crop, color tune 10 photos.</p>
-        <a class="pill" href="#book">Add at checkout →</a>
-      </article>
-      <article class="card">
-        <h3>Restaurant Lite</h3>
-        <p>Pickup ordering (PayPal), ≤12 items.</p>
-        <a class="pill" href="#restaurant">See demo →</a>
-      </article>
     </div>
   </div>
 </section>
@@ -227,7 +223,8 @@
       <div style="display:flex;flex-wrap:wrap;gap:10px;margin:12px 0">
         <a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15" target="_blank" rel="noopener">Open booking link</a>
         <a class="btn btn-outline" href="https://square.link/u/JCKqtjo5" target="_blank" rel="noopener" id="pay-deposit">Pay $50 deposit</a>
-        <a class="btn btn-outline" href="https://square.link/u/24s8uLsE" target="_blank" rel="noopener" id="pay-balance">Pay $449 launch balance (plus tax*)</a>
+        <a class="btn" href="https://square.link/u/u08vlvAR" target="_blank" rel="noopener">Pay in full + choose add-ons →</a>
+        <a class="pill" href="https://square.link/u/wL2hwxEx" target="_blank" rel="noopener">Subscribe to Care (monthly)</a>
       </div>
       <p><strong>Prefer to call or email?</strong><br>
         Call or text <a href="tel:18145808040">814‑580‑8040</a> ·
@@ -280,7 +277,7 @@
       <div id="thanks" class="small" style="display:none;margin-top:12px;color:var(--success)">
         ✅ Thanks! Your message was sent. I’ll reply shortly.
       </div>
-      <p class="small" style="margin-top:10px;color:var(--ink-2)">This form uses FormSubmit (free). We never sell your info. For faster replies, include your link(s) and ideal launch weekend.</p>
+      <p class="small" style="margin-top:10px;color:var(--ink-2)">This form uses FormSubmit (free). We never sell your info. For faster replies, include your link(s) and ideal launch window.</p>
     </div>
   </div>
 </section>
@@ -295,7 +292,7 @@
     </details>
     <details class="card" style="padding:12px">
       <summary>How do payments work?</summary>
-      <p>$50 deposit to hold the weekend; balance on launch via Square. PA clients: development is taxable when transferred.</p>
+      <p>$50 deposit to hold your build window; balance on launch via Square. PA clients: development is taxable when transferred.</p>
     </details>
     <details class="card" style="padding:12px">
       <summary>Is there a monthly fee?</summary>
@@ -395,7 +392,7 @@
     {"@type":"Question","name":"What do you need from me to start?",
      "acceptedAnswer":{"@type":"Answer","text":"Logo or name, brand color, services, hours, address, and 3–6 photos."}},
     {"@type":"Question","name":"How do payments work?",
-     "acceptedAnswer":{"@type":"Answer","text":"$50 deposit to hold the weekend; balance on launch via Square. PA clients: development is taxable when transferred."}},
+     "acceptedAnswer":{"@type":"Answer","text":"$50 deposit to hold your build window; balance on launch via Square. PA clients: development is taxable when transferred."}},
     {"@type":"Question","name":"Is there a monthly fee?",
      "acceptedAnswer":{"@type":"Answer","text":"No. $499 is flat for your 48-hour build and launch. After launch, you can DIY everything (I give you the handoff doc), or choose an optional Site Steward plan if you want me to keep an eye on renewals, DNS/SSL, and tiny tweaks."}}
   ]

--- a/privacy.html
+++ b/privacy.html
@@ -21,6 +21,8 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>⚡</text></svg>">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://square.link">
+  <link rel="preconnect" href="https://checkout.square.site">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 

--- a/refunds.html
+++ b/refunds.html
@@ -21,6 +21,8 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>⚡</text></svg>">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://square.link">
+  <link rel="preconnect" href="https://checkout.square.site">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 
@@ -69,7 +71,7 @@
   </header>
   <main class="container" style="padding-top:40px">
     <h1>Refund Policy</h1>
-    <p>The $50 deposit reserves your build weekend and is non‑refundable once paid. If you need to reschedule before work begins, the deposit can be applied to a future weekend. After launch, all payments are final.</p>
+    <p>The $50 deposit reserves your build window and is non‑refundable once paid. If you need to reschedule before work begins, the deposit can be applied to a future window. After launch, all payments are final.</p>
   </main>
   <footer>
     <div class="footgrid">

--- a/styles.css
+++ b/styles.css
@@ -102,7 +102,7 @@ section p{color:var(--ink-2)}
 }
 
 /* Avoid anchor being hidden by sticky header */
-html,body{scroll-padding-top:72px;} /* adjust to actual header height */
+html{scroll-padding-top:72px;}
 
 #mobile-sticky{display:none}
 @media (max-width:900px){

--- a/terms.html
+++ b/terms.html
@@ -21,6 +21,8 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>⚡</text></svg>">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://square.link">
+  <link rel="preconnect" href="https://checkout.square.site">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 
@@ -69,7 +71,7 @@
   </header>
   <main class="container" style="padding-top:40px">
     <h1>Terms of Service</h1>
-    <p>Booking a One‑Weekend Website requires a $50 non‑refundable deposit to reserve your build weekend. The remaining balance is due upon launch. You agree to provide all necessary content and assets before the scheduled build day. Finished sites are delivered as‑is, and you retain ownership of your content and domain.</p>
+    <p>Booking a One‑Weekend Website requires a $50 non‑refundable deposit to reserve your build window. The remaining balance is due upon launch. You agree to provide all necessary content and assets before the scheduled build day. Finished sites are delivered as‑is, and you retain ownership of your content and domain.</p>
   </main>
   <footer>
     <div class="footgrid">


### PR DESCRIPTION
## Summary
- add four-path checkout CTAs for deposit, full payment with add-ons, and Care subscription
- detail optional add-ons and update copy to "any two-day window"
- add Square performance preconnects, lazy-load work images, and fix sticky header anchors

## Testing
- `npx --yes html-validate index.html terms.html privacy.html refunds.html && echo 'html ok'`
- `npx --yes stylelint styles.css && echo 'stylelint ok'`


------
https://chatgpt.com/codex/tasks/task_e_68bd18708ed88331bb422a5dc673e482