### PR TITLE
Add tagline to navigation and hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,14 @@
       <span>One-Weekend Websites</span>
     </a>
 
+    <div class="tagline header-tagline">
+      <span>Trust that shows</span>
+      <span class="dot">⚫</span>
+      <span>Traffic grows</span>
+      <span class="dot">⚫</span>
+      <span>Revenue flows</span>
+    </div>
+
     <!-- Mobile toggle -->
     <button id="nav-toggle"
             class="nav-toggle"
@@ -78,6 +86,7 @@
   <div class="container" style="padding:48px 0 24px">
     <h1>Your website, live in 48 hours — $499 flat.</h1>
     <p class="lead">Launch-ready in 48 hours. Pick any two-day window—no hourly surprises.</p>
+    <p class="tagline hero-tagline">Trust that shows <span class="dot">⚫</span> Traffic grows <span class="dot">⚫</span> Revenue flows</p>
     <div class="cta-row" style="display:flex;gap:10px;flex-wrap:wrap;margin-top:12px">
       <a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15">Book free fit check</a>
       <a class="btn btn-outline" href="https://square.link/u/JCKqtjo5" target="_blank" rel="noopener">Pay $50 deposit</a>

--- a/styles.css
+++ b/styles.css
@@ -58,6 +58,12 @@ section p{color:var(--ink-2)}
 .logo{border-radius:10px}
 .brand{display:flex;align-items:center;gap:10px;color:#0b1220;text-decoration:none;font-weight:700}
 
+.tagline{display:flex;align-items:center;gap:8px;font-weight:600;color:var(--ink-2);flex-wrap:wrap}
+.tagline .dot{font-size:10px;color:var(--brand)}
+.header-tagline{margin-left:20px;font-size:14px;white-space:nowrap}
+@media (max-width:900px){.header-tagline{display:none}}
+.hero-tagline{justify-content:center;margin:12px 0 0;font-size:18px;text-align:center}
+
 /* Desktop nav */
 .site-nav{display:block}
 .nav-list{display:flex;gap:12px;align-items:center;margin:0;padding:0;list-style:none}


### PR DESCRIPTION
## Summary
- add "Trust that shows ⚫ Traffic grows ⚫ Revenue flows" tagline to navigation bar and hero
- add responsive styling for tagline, hiding it on mobile header and centering in hero

## Testing
- `npx --yes stylelint styles.css`
- `npx --yes html-validate index.html`


------
https://chatgpt.com/codex/tasks/task_e_68bda289c11083319c80ee5749b81951