### PR TITLE
Ensure fade-in sections remain visible without JavaScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <link rel="preconnect" href="https://cal.com">
   <link rel="preconnect" href="https://square.link">
   <link rel="preconnect" href="https://checkout.square.site">
+  <script>if('IntersectionObserver' in window){document.documentElement.classList.add('js');}</script>
   <link rel="stylesheet" href="styles.css">
 
   <!-- Google tag (gtag.js) -->
@@ -394,6 +395,7 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {
+  if(!('IntersectionObserver' in window)) return;
   const faders = document.querySelectorAll('.fade-in');
   const observer = new IntersectionObserver(entries => {
     entries.forEach(entry => {

--- a/styles.css
+++ b/styles.css
@@ -123,6 +123,7 @@ input,textarea{width:100%;padding:10px;border-radius:12px;border:1px solid #E5ED
 .small{font-size:14px;color:var(--ink-2)}
 footer{margin:40px 0 20px;color:var(--ink-2);font-size:14px}
 
-.fade-in{opacity:0;transform:translateY(20px);transition:opacity .6s ease-out,transform .6s ease-out}
-.fade-in.visible{opacity:1;transform:none}
+.fade-in{transition:opacity .6s ease-out,transform .6s ease-out}
+.js .fade-in{opacity:0;transform:translateY(20px)}
+.js .fade-in.visible{opacity:1;transform:none}
 @media (prefers-reduced-motion: reduce){.fade-in{transition:none}}


### PR DESCRIPTION
## Summary
- Only apply fade-in animations when `IntersectionObserver` is supported
- Default sections and footer to visible; hide them via `.js` class only when animations can run
- Guard the fade-in script so unsupported browsers skip animation logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be031d909483319bcaa5ae162e8dcc