### PR TITLE
Fix policy footer links to navigate correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -428,9 +428,9 @@
     <nav class="justify-self-center" aria-label="Footer">
       <ul class="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm">
         <li><a href="https://jordanlander.com" target="_blank" rel="noopener" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">About me</a></li>
-        <li><a href="/terms.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Terms</a></li>
-        <li><a href="/refunds.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Refunds</a></li>
-        <li><a href="/privacy.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Privacy</a></li>
+        <li><a href="terms.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Terms</a></li>
+        <li><a href="refunds.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Refunds</a></li>
+        <li><a href="privacy.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Privacy</a></li>
         <li class="hidden sm:block text-slate-400">•</li>
         <li><a href="#process" class="text-slate-600 hover:text-slate-900">Process</a></li>
         <li><a href="#work" class="text-slate-600 hover:text-slate-900">Work</a></li>

--- a/privacy.html
+++ b/privacy.html
@@ -70,10 +70,10 @@
       <!-- Nav -->
       <nav id="site-nav" class="site-nav" aria-label="Main" hidden>
         <ul class="nav-list">
-          <li><a href="/#process">Process</a></li>
-          <li><a href="/#work">Work</a></li>
-          <li><a href="/#pricing">Pricing</a></li>
-          <li><a href="/#faq">FAQ</a></li>
+          <li><a href="index.html#process">Process</a></li>
+          <li><a href="index.html#work">Work</a></li>
+          <li><a href="index.html#pricing">Pricing</a></li>
+          <li><a href="index.html#faq">FAQ</a></li>
           <li class="nav-cta"><a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15">Book free fit check</a></li>
         </ul>
       </nav>
@@ -95,18 +95,18 @@
       <nav class="justify-self-center" aria-label="Footer">
         <ul class="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm">
           <li><a href="https://jordanlander.com" target="_blank" rel="noopener" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">About me</a></li>
-          <li><a href="/terms.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Terms</a></li>
-          <li><a href="/refunds.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Refunds</a></li>
-          <li><a href="/privacy.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Privacy</a></li>
+          <li><a href="terms.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Terms</a></li>
+          <li><a href="refunds.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Refunds</a></li>
+          <li><a href="privacy.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Privacy</a></li>
           <li class="hidden sm:block text-slate-400">•</li>
-          <li><a href="/#process" class="text-slate-600 hover:text-slate-900">Process</a></li>
-          <li><a href="/#work" class="text-slate-600 hover:text-slate-900">Work</a></li>
-          <li><a href="/#pricing" class="text-slate-600 hover:text-slate-900">Pricing</a></li>
-          <li><a href="/#faq" class="text-slate-600 hover:text-slate-900">FAQ</a></li>
+          <li><a href="index.html#process" class="text-slate-600 hover:text-slate-900">Process</a></li>
+          <li><a href="index.html#work" class="text-slate-600 hover:text-slate-900">Work</a></li>
+          <li><a href="index.html#pricing" class="text-slate-600 hover:text-slate-900">Pricing</a></li>
+          <li><a href="index.html#faq" class="text-slate-600 hover:text-slate-900">FAQ</a></li>
         </ul>
       </nav>
       <div class="justify-self-end flex flex-wrap gap-2 text-sm">
-        <a href="/#book" class="px-3 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">Book</a>
+        <a href="index.html#book" class="px-3 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">Book</a>
         <a href="https://square.link/u/JCKqtjo5" class="px-3 py-2 rounded-md border">Deposit</a>
         <a href="https://square.link/u/u08vlvAR" class="px-3 py-2 rounded-md border">Pay in full</a>
         <a href="https://square.link/u/wL2hwxEx" class="px-3 py-2 rounded-md border">Care</a>
@@ -114,7 +114,7 @@
     </div>
   </footer>
   <div id="mobile-sticky">
-    <a class="btn btn-primary" href="/#book">Book</a>
+    <a class="btn btn-primary" href="index.html#book">Book</a>
     <a class="btn btn-outline" href="tel:18145808040">Call/Text</a>
   </div>
   <script>

--- a/refunds.html
+++ b/refunds.html
@@ -70,10 +70,10 @@
       <!-- Nav -->
       <nav id="site-nav" class="site-nav" aria-label="Main" hidden>
         <ul class="nav-list">
-          <li><a href="/#process">Process</a></li>
-          <li><a href="/#work">Work</a></li>
-          <li><a href="/#pricing">Pricing</a></li>
-          <li><a href="/#faq">FAQ</a></li>
+          <li><a href="index.html#process">Process</a></li>
+          <li><a href="index.html#work">Work</a></li>
+          <li><a href="index.html#pricing">Pricing</a></li>
+          <li><a href="index.html#faq">FAQ</a></li>
           <li class="nav-cta"><a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15">Book free fit check</a></li>
         </ul>
       </nav>
@@ -95,18 +95,18 @@
       <nav class="justify-self-center" aria-label="Footer">
         <ul class="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm">
           <li><a href="https://jordanlander.com" target="_blank" rel="noopener" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">About me</a></li>
-          <li><a href="/terms.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Terms</a></li>
-          <li><a href="/refunds.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Refunds</a></li>
-          <li><a href="/privacy.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Privacy</a></li>
+          <li><a href="terms.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Terms</a></li>
+          <li><a href="refunds.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Refunds</a></li>
+          <li><a href="privacy.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Privacy</a></li>
           <li class="hidden sm:block text-slate-400">•</li>
-          <li><a href="/#process" class="text-slate-600 hover:text-slate-900">Process</a></li>
-          <li><a href="/#work" class="text-slate-600 hover:text-slate-900">Work</a></li>
-          <li><a href="/#pricing" class="text-slate-600 hover:text-slate-900">Pricing</a></li>
-          <li><a href="/#faq" class="text-slate-600 hover:text-slate-900">FAQ</a></li>
+          <li><a href="index.html#process" class="text-slate-600 hover:text-slate-900">Process</a></li>
+          <li><a href="index.html#work" class="text-slate-600 hover:text-slate-900">Work</a></li>
+          <li><a href="index.html#pricing" class="text-slate-600 hover:text-slate-900">Pricing</a></li>
+          <li><a href="index.html#faq" class="text-slate-600 hover:text-slate-900">FAQ</a></li>
         </ul>
       </nav>
       <div class="justify-self-end flex flex-wrap gap-2 text-sm">
-        <a href="/#book" class="px-3 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">Book</a>
+        <a href="index.html#book" class="px-3 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">Book</a>
         <a href="https://square.link/u/JCKqtjo5" class="px-3 py-2 rounded-md border">Deposit</a>
         <a href="https://square.link/u/u08vlvAR" class="px-3 py-2 rounded-md border">Pay in full</a>
         <a href="https://square.link/u/wL2hwxEx" class="px-3 py-2 rounded-md border">Care</a>
@@ -114,7 +114,7 @@
     </div>
   </footer>
   <div id="mobile-sticky">
-    <a class="btn btn-primary" href="/#book">Book</a>
+    <a class="btn btn-primary" href="index.html#book">Book</a>
     <a class="btn btn-outline" href="tel:18145808040">Call/Text</a>
   </div>
   <script>

--- a/terms.html
+++ b/terms.html
@@ -70,10 +70,10 @@
       <!-- Nav -->
       <nav id="site-nav" class="site-nav" aria-label="Main" hidden>
         <ul class="nav-list">
-          <li><a href="/#process">Process</a></li>
-          <li><a href="/#work">Work</a></li>
-          <li><a href="/#pricing">Pricing</a></li>
-          <li><a href="/#faq">FAQ</a></li>
+          <li><a href="index.html#process">Process</a></li>
+          <li><a href="index.html#work">Work</a></li>
+          <li><a href="index.html#pricing">Pricing</a></li>
+          <li><a href="index.html#faq">FAQ</a></li>
           <li class="nav-cta"><a class="btn btn-primary" href="https://cal.com/jordanlander/fit-check-15">Book free fit check</a></li>
         </ul>
       </nav>
@@ -95,18 +95,18 @@
       <nav class="justify-self-center" aria-label="Footer">
         <ul class="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm">
           <li><a href="https://jordanlander.com" target="_blank" rel="noopener" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">About me</a></li>
-          <li><a href="/terms.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Terms</a></li>
-          <li><a href="/refunds.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Refunds</a></li>
-          <li><a href="/privacy.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Privacy</a></li>
+          <li><a href="terms.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Terms</a></li>
+          <li><a href="refunds.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Refunds</a></li>
+          <li><a href="privacy.html" class="text-slate-600 hover:text-slate-900 underline decoration-dotted">Privacy</a></li>
           <li class="hidden sm:block text-slate-400">•</li>
-          <li><a href="/#process" class="text-slate-600 hover:text-slate-900">Process</a></li>
-          <li><a href="/#work" class="text-slate-600 hover:text-slate-900">Work</a></li>
-          <li><a href="/#pricing" class="text-slate-600 hover:text-slate-900">Pricing</a></li>
-          <li><a href="/#faq" class="text-slate-600 hover:text-slate-900">FAQ</a></li>
+          <li><a href="index.html#process" class="text-slate-600 hover:text-slate-900">Process</a></li>
+          <li><a href="index.html#work" class="text-slate-600 hover:text-slate-900">Work</a></li>
+          <li><a href="index.html#pricing" class="text-slate-600 hover:text-slate-900">Pricing</a></li>
+          <li><a href="index.html#faq" class="text-slate-600 hover:text-slate-900">FAQ</a></li>
         </ul>
       </nav>
       <div class="justify-self-end flex flex-wrap gap-2 text-sm">
-        <a href="/#book" class="px-3 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">Book</a>
+        <a href="index.html#book" class="px-3 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">Book</a>
         <a href="https://square.link/u/JCKqtjo5" class="px-3 py-2 rounded-md border">Deposit</a>
         <a href="https://square.link/u/u08vlvAR" class="px-3 py-2 rounded-md border">Pay in full</a>
         <a href="https://square.link/u/wL2hwxEx" class="px-3 py-2 rounded-md border">Care</a>
@@ -114,7 +114,7 @@
     </div>
   </footer>
   <div id="mobile-sticky">
-    <a class="btn btn-primary" href="/#book">Book</a>
+    <a class="btn btn-primary" href="index.html#book">Book</a>
     <a class="btn btn-outline" href="tel:18145808040">Call/Text</a>
   </div>
   <script>


### PR DESCRIPTION
## Summary
- Use relative URLs for Terms, Refunds, and Privacy footer links
- Route policy page nav links back to index sections with `index.html#` anchors

## Testing
- `npx -y html-validate index.html privacy.html refunds.html terms.html`
- `npx -y stylelint styles.css`


------
https://chatgpt.com/codex/tasks/task_e_68c381d2f5dc8331848b9ffd94edc3cd