### PR TITLE
Clarify refund policy with non-refundable deposit and revision limits

### DIFF
--- a/refunds.html
+++ b/refunds.html
@@ -84,7 +84,7 @@
   </header>
   <main class="px-6 py-16 max-w-3xl mx-auto">
     <h1 class="text-3xl font-extrabold mb-4">Refund Policy</h1>
-    <p class="text-slate-600">The $50 deposit reserves your build window and is non‑refundable once paid. If you need to reschedule before work begins, the deposit can be applied to a future window. After launch, all payments are final.</p>
+    <p class="text-slate-600">A $50 deposit reserves your build window and is non‑refundable once paid. You may reschedule before work begins and apply the deposit to a future window. Once design and build work starts, all fees are non‑refundable. After launch, you have 14 days for up to two rounds of reasonable revisions to ensure the site matches the agreed scope. Additional changes or new features will be billed separately.</p>
   </main>
   <footer class="px-6 py-10 border-t">
     <div class="max-w-6xl mx-auto grid gap-6 md:grid-cols-3 items-center">


### PR DESCRIPTION
## Summary
- clarify deposit is non-refundable yet can be moved if rescheduled
- limit post-launch revisions to two rounds within 14 days, with further changes billed

## Testing
- `npx -y html-validate index.html privacy.html refunds.html terms.html`
- `npx -y stylelint styles.css`
- `npx -y linkinator terms.html privacy.html refunds.html --recurse --silent --skip 'https://.*' --skip 'mailto:.*' --skip 'tel:.*' --skip '/favicon.*' --skip '/apple-touch-icon.png' --skip '/web-app.*'`


------
https://chatgpt.com/codex/tasks/task_e_68c3a464b0048331a60477c974a538a6