### PR TITLE
Add FAQ clarifying build schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,6 +414,10 @@
       <summary>Is there a monthly fee?</summary>
       <p>No. $499 is flat for your 48-hour build and launch. After launch, you can DIY everything (I give you the handoff doc), or choose an optional Care plan if you want me to keep an eye on DNS/HTTPS, uptime, and monthly content updates.</p>
     </details>
+    <details class="card" style="padding:12px">
+      <summary>Do you only build on weekends?</summary>
+      <p>Nope. We build in 48 hours, whether that’s Monday–Tuesday or Friday–Saturday. We called it One-Weekend Websites because the process is short, focused, and fast.</p>
+    </details>
     </div>
   </div>
 </section>
@@ -541,6 +545,8 @@ document.addEventListener('DOMContentLoaded', () => {
      "acceptedAnswer":{"@type":"Answer","text":"$50 deposit to hold your build window; balance on launch via Square. PA clients: development is taxable when transferred."}},
     {"@type":"Question","name":"Is there a monthly fee?",
      "acceptedAnswer":{"@type":"Answer","text":"No. $499 is flat for your 48-hour build and launch. After launch, you can DIY everything (I give you the handoff doc), or choose an optional Care plan if you want me to keep an eye on DNS/HTTPS, uptime, and monthly content updates."}}
+    ,{"@type":"Question","name":"Do you only build on weekends?",
+     "acceptedAnswer":{"@type":"Answer","text":"Nope. We build in 48 hours, whether that’s Monday–Tuesday or Friday–Saturday. We called it One-Weekend Websites because the process is short, focused, and fast."}}
   ]
 }
 </script>


### PR DESCRIPTION
## Summary
- add FAQ entry explaining builds can happen any 48-hour period
- sync FAQ structured data with the new entry

## Testing
- `npx -y html-validate index.html privacy.html refunds.html terms.html`
- `npx -y stylelint styles.css`
- `npx -y linkinator terms.html privacy.html refunds.html --recurse --silent --skip 'https://.*' --skip 'mailto:.*' --skip 'tel:.*' --skip '/favicon.*' --skip '/apple-touch-icon.png' --skip '/web-app.*'`


------
https://chatgpt.com/codex/tasks/task_e_68c5ce59f96483318daf35f78facfed3